### PR TITLE
chore: broadon type constraint for `DAYS` argument

### DIFF
--- a/src/biggo_mcp_server/services/price_history.py
+++ b/src/biggo_mcp_server/services/price_history.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from logging import getLogger
-from typing import Literal
+from typing import Any, Literal
 from aiohttp import ClientSession
 from ..types.api_ret.price_history import PriceHistoryAPIRet
 from ..lib.utils import get_nindex_from_url, get_nindex_oid, get_pid_from_url
@@ -8,7 +8,7 @@ from ..types.setting import BigGoMCPSetting
 
 logger = getLogger(__name__)
 
-DAYS = Literal["90", 90, "80", 80, "365", 365, "730", 730]
+DAYS = Literal["90", "80", "365", "730"] | Any
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
For some reason some models will have this kind of error when using tools with the `DAYS` argument.
Which previously had a type alias of `Literal[ "90", 90, .....]` containing both string and integer type
```bash
2025-03-06 11:03:41 error: Error in handleProcessQuery: json: cannot unmarshal number into Go struct field .tools.function.parameters.properties.enum of type string
2025-03-06 11:03:41 error: [83c569c2-0dd8-4df8-94aa-ffc41bce5862] Error processing query: json: cannot unmarshal number into Go struct field .tools.function.parameters.properties.enum of type string
2025-03-06 11:03:41 error: Stream error: json: cannot unmarshal number into Go struct field .tools.function.parameters.properties.enum of type string
```