### PR TITLE
fix(server): make SSE/stdio mutually exclusive and guard SIGKILL on Windows

### DIFF
--- a/src/biggo_mcp_server/lib/server.py
+++ b/src/biggo_mcp_server/lib/server.py
@@ -46,12 +46,12 @@ class BigGoMCPServer(FastMCP):
             self._end_event.set()
 
     async def start(self):
-        stdio_bg = create_task(self._run_stdio_async(), name="stdio-bg")
-        self._bg.append(stdio_bg)
-
         if self.biggo_setting.server_type == "sse":
             sse_bg = create_task(self._run_sse_async(), name="sse-bg")
             self._bg.append(sse_bg)
+        else:
+            stdio_bg = create_task(self._run_stdio_async(), name="stdio-bg")
+            self._bg.append(stdio_bg)
 
     async def _cleanup(self):
         for task in self._bg:
@@ -63,4 +63,4 @@ class BigGoMCPServer(FastMCP):
         logger.info("Server shutting down")
         await self._cleanup()
         logger.info("Server shutdown complete")
-        os.kill(os.getpid(), signal.SIGKILL)
+        os.kill(os.getpid(), getattr(signal, "SIGKILL", signal.SIGTERM))


### PR DESCRIPTION
## Summary

Two small, unrelated bugs in `src/biggo_mcp_server/lib/server.py` combine to make `SERVER_TYPE=sse` unusable on Windows. Both fixes together are 4 changed lines.

### Bug 1 — `start()` always launches the stdio task

`start()` unconditionally creates the stdio background task and only *additionally* starts the SSE task when `server_type == "sse"`. On Windows in an interactive shell (the common case for running BigGo as a local daemon for Claude Desktop / Claude Code), `sys.stdin.buffer` is `None`, so `run_stdio_async()` raises `AttributeError: 'NoneType' object has no attribute 'buffer'` immediately. The stdio task's `finally` clause then sets `_end_event`, which `wait_finish()` is already awaiting — so the SSE task is cancelled before it can serve a single request.

**Fix:** launch stdio only when `server_type != "sse"`. This matches the documented mutually-exclusive choices for `SERVER_TYPE` and means SSE mode no longer depends on stdin being a real pipe.

### Bug 2 — `signal.SIGKILL` doesn't exist on Windows

`wait_finish()` ends with `os.kill(os.getpid(), signal.SIGKILL)`. `SIGKILL` is POSIX-only; on Windows merely accessing `signal.SIGKILL` raises `AttributeError` and crashes shutdown.

**Fix:** `getattr(signal, "SIGKILL", signal.SIGTERM)`. Windows's `os.kill` maps `SIGTERM` to `TerminateProcess`, which gives the same self-shutdown semantics. POSIX behaviour is unchanged.

## Why this matters

Without these patches BigGo-MCP-Server cannot run in SSE mode on Windows at all, which rules out the persistent-daemon deployment pattern that hosted-MCP clients (Claude Code, Claude Desktop) expect on that platform. With them, `uvx biggo-mcp-server` with `SERVER_TYPE=sse` runs cleanly on Windows 11 and stays up across client reconnects.

## Test plan

- [x] Patched `server.py` in a local `uv tool` install on Windows 11; `BigGo-MCP-Server` boots in SSE mode, binds `http://localhost:9876/sse`, and serves tool calls from Claude Code (verified with `product_search` and `price_history_with_url`).
- [x] `Ctrl+C` shutdown no longer raises `AttributeError` on Windows.
- [ ] Linux / macOS regression: behaviour unchanged — `getattr(signal, "SIGKILL", ...)` returns `signal.SIGKILL` on POSIX, and `server_type == "stdio"` still launches the stdio task via the new `else` branch.

Happy to split into two commits or adjust style if preferred.